### PR TITLE
Add timestamp to verbose output TX: line like that of the RX: line

### DIFF
--- a/aprsdigi.c
+++ b/aprsdigi.c
@@ -1050,7 +1050,10 @@ xmit(struct stuff *s, struct interface_list *dupelist)
 	  fclose(of);
       }
       if (Verbose) {
-	fprintf(stderr,"%s: TX: ",l->i->port);
+	char buf[20];
+	time_t tick = time(0);
+	strftime(buf,sizeof(buf),"%T",gmtime(&tick));
+	fprintf(stderr,"%s %s: TX: ",buf,l->i->port);
 	print_it(stderr,&calls,op-(vecl[n]+l->i->taglen),vecl[n]+l->i->taglen);
       }
       ++l->i->stats.tx;


### PR DESCRIPTION
A simple change to add a time to the TX: verbose message corresponding to the time in the RX: message. A TX: message is often followed by an RX: message in stderr when a new message is received. The difference in timestamps will provide the  channel idle time between them.