### PR TITLE
Fix rx_flood return to produce the ending verbose message with or wit…

### DIFF
--- a/aprsdigi.c
+++ b/aprsdigi.c
@@ -793,7 +793,7 @@ rx_flood(struct stuff *s)
     ++s->i->stats.flood;
     if (xmit(s,NULL) < 0) 
       perror("xmit");
-    return 1;
+    result = 1;
   }
   if (Verbose) {
     fprintf(stderr,"Did %s require special flooding handling.\n",


### PR DESCRIPTION
The existing " return 1" means the message is never issued when flooding handling has been done. With the change the same value is returned but the message is issued to stderr (when verbose is active).

_Tiny cleanup._