### PR TITLE
Fix tpying errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ features implemented include:
 - Single-interface conventional UI-frame digipeating.
 - Cross-interface digipeating (also known as bridging, routing or gatewaying) and one-to-many fanout.
 - Substitution of a digipeated alias with the interface's callsign (typically used to substitute RELAY, WIDE or TRACE aliases).
-- WIDEn-n flooding algorithim.
+- WIDEn-n flooding algorithm.
 - TRACEn-n route recording.
 - Mic-Encoder(tm) support, including SSID-based digipeating, decompression of packets into the conventional APRS MIM format. (The Mic-Encoder compression is also used by other products such as the Kenwood TH-D7A and D700, and TAPR PIC-Encoder).
 - TheNet X1J4 node beacon text translation (removal of the lqTheNet X1J4 (alias)rq prefix from the btext).

--- a/TODO
+++ b/TODO
@@ -38,7 +38,7 @@ aprsdigi:
     netcat ./nc -v -u -p 14439 -l | ./nc -v -l -p 14439 localhost 
   - make aprs-is compatible (see aprsd/doc/q.html) or just use aprsd?
   - add file: and/or tty: intf type to support non-KISS-capable TNCs 
-    and broken KISS implentations like TH-D7A (this is getting gross).
+    and broken KISS implementations like TH-D7A (this is getting gross).
   - support more than 8 digipeaters in cooked mode?
   - digipeat other than UI frames (digi_ned && requested for opentrac pid 99)
   - Combine unproto() and parsecalls().

--- a/aprsdigi.8
+++ b/aprsdigi.8
@@ -55,7 +55,7 @@ or
 aliases).
 .IP \(bu 2
 .BI "WIDEn-n"
-flooding algorithim.
+flooding algorithm.
 .IP \(bu 2
 .BI "TRACEn-n"
 route recording.

--- a/aprsdigi.c
+++ b/aprsdigi.c
@@ -903,7 +903,7 @@ rx_digi(struct stuff *s)
     if (Verbose) {
       fprintf(stderr,"Got a conventional digipeat.\n");
     }
-      s->out = s->in;	/* copy input list to output unmodifed */
+      s->out = s->in;	/* copy input list to output unmodified */
       s->out.ax_digi_call[s->out.ax_next_digi].ax25_call[ALEN] |= REPEATED;
       ++s->i->stats.digi;
       if (xmit(s,NULL) < 0) 
@@ -1167,7 +1167,7 @@ xmit(struct stuff *s, struct interface_list *dupelist)
  */
 struct pkt {
   struct pkt *next,*prev;
-  time_t t;			/* when recevied */
+  time_t t;			/* when received */
   ax25_address to;		/* destination */
   ax25_address fr;		/* source */
   int l;			/* length of text */
@@ -1305,7 +1305,7 @@ loop_packet(struct ax_calls *calls,u_char *cp,int len)
 
 static void
 cleanup(sig)
-int sig;			/* dont't really care what it was */
+int sig;			/* don't really care what it was */
 {
   if (alarm(0) > 0)		/* an alarm was pending, so... */
     sked_id(NULL);		/*  ID one last time */

--- a/depcomp
+++ b/depcomp
@@ -254,7 +254,7 @@ tru64)
 
 dashmstdout)
   # Important note: in order to support this mode, a compiler *must*
-  # always write the proprocessed file to stdout, regardless of -o.
+  # always write the preprocessed file to stdout, regardless of -o.
   "$@" || exit $?
 
   # Remove the call to Libtool.
@@ -339,7 +339,7 @@ makedepend)
 
 cpp)
   # Important note: in order to support this mode, a compiler *must*
-  # always write the proprocessed file to stdout.
+  # always write the preprocessed file to stdout.
   "$@" || exit $?
 
   # Remove the call to Libtool.
@@ -381,7 +381,7 @@ cpp)
 
 msvisualcpp)
   # Important note: in order to support this mode, a compiler *must*
-  # always write the proprocessed file to stdout, regardless of -o,
+  # always write the preprocessed file to stdout, regardless of -o,
   # because we must use -o when running libtool.
   "$@" || exit $?
   IFS=" "

--- a/mic_e.c
+++ b/mic_e.c
@@ -200,7 +200,7 @@ fmt_mic_e(const u_char *t,	/* tocall */
 }
 
 /*
- * here's another APRS device that get's mistreated by some APRS
+ * here's another APRS device that gets mistreated by some APRS
  * implementations:  A TNC2 running TheNet X1J4.
  *
  *          1         2


### PR DESCRIPTION
This PR fixes some small errors in the documentation and in comments.

Fixed with:
codespell --ignore-words-list=bu,nott,padd --write-changes