### PR TITLE
Fix implicit ints and implicit function declarations (C99 compat)

### DIFF
--- a/aprsdigi.c
+++ b/aprsdigi.c
@@ -45,6 +45,7 @@ static char copyr[] = "Copyright (c) 1996,1997,1999,2001,2002,2003,2004,2009,201
 #include <sys/un.h>
 #include <net/if.h>
 #include <netinet/if_ether.h>
+#include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
@@ -55,7 +56,8 @@ static char copyr[] = "Copyright (c) 1996,1997,1999,2001,2002,2003,2004,2009,201
 #include <time.h>
 #include <signal.h>
 #include <errno.h>
-#include <linux/ax25.h>
+#include <netax25/ax25.h>
+#include <netax25/axlib.h>
 #ifndef AX25_MTU
 #define AX25_MTU 256
 #endif

--- a/fiforead.c
+++ b/fiforead.c
@@ -20,6 +20,7 @@ int Verbose = 1;
 
 static void die(char *s);
 
+int
 main(int argc, char **argv)
 {
   struct sockaddr_un mysun,remsun;

--- a/fifowrite.c
+++ b/fifowrite.c
@@ -20,6 +20,7 @@ int Verbose = 1;
 
 static void die(char *s);
 
+int
 main(int argc, char **argv)
 {
   struct sockaddr_un mysun;

--- a/libax25ext.c
+++ b/libax25ext.c
@@ -8,6 +8,7 @@
 #ifndef HAVE_LIBAX25_EXTENSIONS
 
 #include <netax25/ax25.h>
+#include <netax25/axlib.h>
 #include <netrose/rose.h>
 #include "libax25ext.h"
 #include <string.h>

--- a/testmcast.c
+++ b/testmcast.c
@@ -6,6 +6,7 @@
 #include <sys/socket.h>
 #include <net/if.h>
 #include <netinet/if_ether.h>
+#include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
@@ -31,6 +32,7 @@ die(char *p, char *s)
   exit(1);
 }
 
+int
 main(int argc,char **argv)
 {
   struct sockaddr_in sin;

--- a/testparse.c
+++ b/testparse.c
@@ -25,7 +25,8 @@ static void print_it(FILE *f,
 	      int len);
 static void drop_unused_digis(struct ax_calls *);
 
-main()
+int
+main(void)
 {
   unsigned char buf[2048],*bp;
   int buflen, *lp = &buflen;


### PR DESCRIPTION
Include <arpa/inet.h> for inet_addr and inet_ntop.  Include <netax25/axlib.h> for ax25_aton_entry.  To avoid header conflicts, it is necessary to include <netax25/ax25.h> instead of <linux/ax25.h>, too.

This changes avoid build failures with future compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
